### PR TITLE
remove all the things from text

### DIFF
--- a/app/models/github_to_slack/communicator.rb
+++ b/app/models/github_to_slack/communicator.rb
@@ -42,7 +42,7 @@ module GithubToSlack
         .new(WEBHOOK_URL,
           channel: CHANNEL_NAME,
           username: 'Github To Slack')
-        .ping(":allthethings: :octocat: :speaker: " + message)
+        .ping(":octocat: :speaker: " + message)
     end
   end
 end


### PR DESCRIPTION
:allthethings: doesn't exist in everyone's slack. Remove it to make it more _open source_
